### PR TITLE
URL Cleanup

### DIFF
--- a/Spring.Amqp.HelloWorld/Spring.Amqp.HelloWorld.BrokerConfiguration/Program.cs
+++ b/Spring.Amqp.HelloWorld/Spring.Amqp.HelloWorld.BrokerConfiguration/Program.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.Amqp.HelloWorld/Spring.Amqp.HelloWorld.Consumer.Async/HelloWorldHandler.cs
+++ b/Spring.Amqp.HelloWorld/Spring.Amqp.HelloWorld.Consumer.Async/HelloWorldHandler.cs
@@ -8,7 +8,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.Amqp.HelloWorld/Spring.Amqp.HelloWorld.Consumer.Async/Program.cs
+++ b/Spring.Amqp.HelloWorld/Spring.Amqp.HelloWorld.Consumer.Async/Program.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.Amqp.HelloWorld/Spring.Amqp.HelloWorld.Consumer/Program.cs
+++ b/Spring.Amqp.HelloWorld/Spring.Amqp.HelloWorld.Consumer/Program.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.Amqp.HelloWorld/Spring.Amqp.HelloWorld.Producer.Async/Program.cs
+++ b/Spring.Amqp.HelloWorld/Spring.Amqp.HelloWorld.Producer.Async/Program.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.Amqp.HelloWorld/Spring.Amqp.HelloWorld.Producer/Program.cs
+++ b/Spring.Amqp.HelloWorld/Spring.Amqp.HelloWorld.Producer/Program.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.BrokerConfiguration/Program.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.BrokerConfiguration/Program.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/Gateways/IStockService.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/Gateways/IStockService.cs
@@ -9,7 +9,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/Gateways/IStockServiceGateway.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/Gateways/IStockServiceGateway.cs
@@ -9,7 +9,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/Gateways/ISyncStockService.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/Gateways/ISyncStockService.cs
@@ -9,7 +9,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/Gateways/RabbitStockServiceGateway.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/Gateways/RabbitStockServiceGateway.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/Handlers/StockAppHandler.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/Handlers/StockAppHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/Program.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/Program.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/UI/StockController.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/UI/StockController.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/UI/StockForm.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Client/UI/StockForm.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Common/Data/Quote.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Common/Data/Quote.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Common/Data/Stock.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Common/Data/Stock.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Common/Data/StockExchange.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Common/Data/StockExchange.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Common/Data/TradeRequest.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Common/Data/TradeRequest.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Common/Data/TradeResponse.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Common/Data/TradeResponse.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Gateways/IMarketDataGateway.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Gateways/IMarketDataGateway.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Gateways/MarketDataGateway.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Gateways/MarketDataGateway.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Handlers/LoggingExceptionListener.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Handlers/LoggingExceptionListener.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Handlers/StockAppHandler.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Handlers/StockAppHandler.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Program.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Program.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Services/ICreditCheckService.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Services/ICreditCheckService.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Services/IExecutionVenueService.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Services/IExecutionVenueService.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Services/ITradingService.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Services/ITradingService.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Services/Stubs/CreditCheckServiceStub.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Services/Stubs/CreditCheckServiceStub.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Services/Stubs/ExecutionVenueServiceStub.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Services/Stubs/ExecutionVenueServiceStub.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Services/Stubs/TradingServiceStub.cs
+++ b/Spring.RabbitQuickStart/src/Spring/Spring.RabbitQuickStart.Server/Services/Stubs/TradingServiceStub.cs
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 31 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).